### PR TITLE
Improve pnpm/autoformat compatibility

### DIFF
--- a/Autoformat/Autoformat.csproj
+++ b/Autoformat/Autoformat.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>0.1.1</VersionPrefix>
+		<VersionPrefix>0.1.2</VersionPrefix>
 
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Autoformat/Autoformat.targets
+++ b/Autoformat/Autoformat.targets
@@ -2,6 +2,11 @@
 	<PropertyGroup>
 		<LintRecordPath Condition=" '$(LintRecordPath)' == '' ">$(IntermediateOutputPath)/_.dpd-lint._</LintRecordPath>
 	</PropertyGroup>
+
+	<ItemGroup Condition=" '$(EditorConfigFiles)' == '' ">
+		<EditorConfigFiles Include="$(SolutionRoot).editorconfig" Visible="false" />
+	</ItemGroup>
+
 	<Target Name="PrepareLint" BeforeTargets="Lint" />
 	<Target Name="Lint"
 	        BeforeTargets="BeforeBuild" />

--- a/Autoformat/README.md
+++ b/Autoformat/README.md
@@ -17,13 +17,9 @@ For solution-wide settings:
 1. Add the reference to `DarkPatterns.Build.Autoformat` via the
    `Directory.Build.props` to ensure autoformat is set for all projects.
 
-2. Ensure `SolutionRoot` is set within the `Directory.Build.props` as follows:
-
-	```xml
-	<SolutionRoot>$(MSBuildThisFileDirectory)</SolutionRoot>
-	```
-
-3. Place the `.editorconfig` in the same folder as your Directory.Build.props.
+2. Place the `.editorconfig` in the same folder as your Directory.Build.props.
+   Alternatively, be sure to include your `.editorconfig` in the
+   `EditorConfigFiles` item.
 
 ## Additional recommendations
 

--- a/Pnpm/Pnpm.csproj
+++ b/Pnpm/Pnpm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>0.1.11</VersionPrefix>
+		<VersionPrefix>0.1.12</VersionPrefix>
 
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Pnpm/Sdk/Pnpm.targets
+++ b/Pnpm/Sdk/Pnpm.targets
@@ -23,6 +23,9 @@
         <PnpmInstallRecordPath Condition=" '$(PnpmInstallRecordPath)' == '' ">$(PnpmRootPath)node_modules\_.install.$(Configuration)._</PnpmInstallRecordPath>
         <PnpmLintRecordPath Condition=" '$(PnpmLintRecordPath)' == '' ">$(PnpmStepRecordDir)_.lint.$(Configuration)._</PnpmLintRecordPath>
     </PropertyGroup>
+    <PropertyGroup>
+        <LintSkipDotnet Condition=" '$(LintSkipDotnet)' == '' ">true</LintSkipDotnet>
+    </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(PnpmInstallProjectPath)" />
     </ItemGroup>


### PR DESCRIPTION
- Autoformat was not applying the editorconfig in all cases according to its docs
- After fixing that, `dotnet format` was updating `.ts` files with a different standard, so the PNPM project disables the corresponding target.