### PR TITLE
Node modules had a too-long path in VS

### DIFF
--- a/Pnpm/Pnpm.csproj
+++ b/Pnpm/Pnpm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>0.1.14</VersionPrefix>
+		<VersionPrefix>0.1.15</VersionPrefix>
 
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Pnpm/Sdk/Pnpm.targets
+++ b/Pnpm/Sdk/Pnpm.targets
@@ -47,6 +47,9 @@
         <Compile Include="src/**" Watch="false" />
     </ItemGroup>
     <ItemGroup>
+        <None Remove="node_modules/**/*" />
+    </ItemGroup>
+    <ItemGroup>
         <Watch Include="@(CompileConfig)" />
         <Watch Include="@(RestoreConfig)" />
     </ItemGroup>


### PR DESCRIPTION
All node_modules were getting added to `<None>` item type, which caused Visual Studio to not be able to load the project. By explicitly removing the files, Visual Studio is fixed.