### PR TITLE
Allow overriding Autoformat results

### DIFF
--- a/Autoformat/Autoformat.csproj
+++ b/Autoformat/Autoformat.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>0.1.2</VersionPrefix>
+		<VersionPrefix>0.2.0</VersionPrefix>
 
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Autoformat/Autoformat.props
+++ b/Autoformat/Autoformat.props
@@ -5,6 +5,7 @@
 
 		<LintSkip>false</LintSkip>
 		<LintEnforceNoChanges Condition=" '$(Configuration)' == 'Release' ">true</LintEnforceNoChanges>
+		<DotnetFormatArgs Condition=" '$(DotnetFormatArgs)' == '' "></DotnetFormatArgs>
 	</PropertyGroup>
 
 	<!-- EditorConfigFiles automatically get loaded from the project's parent directories -->

--- a/Autoformat/Autoformat.targets
+++ b/Autoformat/Autoformat.targets
@@ -3,7 +3,7 @@
 		<LintRecordPath Condition=" '$(LintRecordPath)' == '' ">$(IntermediateOutputPath)/_.dpd-lint._</LintRecordPath>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(EditorConfigFiles)' == '' ">
+	<ItemGroup Condition=" '@(EditorConfigFiles)' == '' ">
 		<EditorConfigFiles Include="$(SolutionRoot).editorconfig" Visible="false" />
 	</ItemGroup>
 
@@ -17,10 +17,10 @@
 	        Outputs="$(LintRecordPath)">
 		<Exec Condition=" '$(LintEnforceNoChanges)' != 'true' "
 		      WorkingDirectory="$(ProjectDir)"
-		      Command="dotnet format &quot;$(ProjectPath)&quot;" />
+		      Command="dotnet format $(DotnetFormatArgs) &quot;$(ProjectPath)&quot;" />
 		<Exec Condition=" '$(LintEnforceNoChanges)' == 'true' "
 		      WorkingDirectory="$(ProjectDir)"
-		      Command="dotnet format &quot;$(ProjectPath)&quot; --verify-no-changes" />
+		      Command="dotnet format $(DotnetFormatArgs) &quot;$(ProjectPath)&quot; --verify-no-changes" />
 		<MakeDir Directories="$(IntermediateOutputPath)"/>
 		<Touch AlwaysCreate="true" ForceTouch="true" Files="$(LintRecordPath)" />
 	</Target>

--- a/Autoformat/README.md
+++ b/Autoformat/README.md
@@ -41,6 +41,7 @@ For solution-wide settings:
 | AnalysisLevel | [See Microsoft's documentation for AnalysisLevel][ms-analysislevel] | `latest-Recommended` |
 | LintSkipDotnet | Skips the Lint target entirely if set to `true` | `false` |
 | LintEnforceNoChanges | When `true`, will not update files but instead will cause an error if not already in the correct format | `true` if Configuration is `Release` |
+| DotnetFormatArgs | Additional arguments for the `dotnet format` command. | Empty |
 
 ### Targets
 

--- a/Pnpm/Pnpm.csproj
+++ b/Pnpm/Pnpm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>0.1.15</VersionPrefix>
+		<VersionPrefix>0.2.0</VersionPrefix>
 
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Pnpm/README.md
+++ b/Pnpm/README.md
@@ -31,7 +31,7 @@ Add build tooling to MSBuild to support PNPM projects!
 | Name | Decription | Default |
 | :--- | :--------- | :------ |
 | CompileOutputs | The files that will be created by the build process | None; required to run build script |
-| Compile | The inputs for build and lint | `src/**` |
+| PnpmCompile | The inputs for build and lint | `src/**` |
 | CompileConfig[^1] | Inputs that could affect build configuration options. | `.*rc` and `*.json` files in the project root |
 | RestoreConfig[^1] | The inputs for the node restore configuration. | `$(PnpmRootPath)package.json`, `$(PnpmRootPath)pnpm-lock.yaml`, and `package.json` |
 | PnpmPackagedFiles | Additional inputs that will cause the packaged files to change | All CompileConfig items |

--- a/Pnpm/README.md
+++ b/Pnpm/README.md
@@ -31,7 +31,7 @@ Add build tooling to MSBuild to support PNPM projects!
 | Name | Decription | Default |
 | :--- | :--------- | :------ |
 | CompileOutputs | The files that will be created by the build process | None; required to run build script |
-| PnpmCompile | The inputs for build and lint | `src/**` |
+| Compile or PnpmCompile | The inputs for build and lint. All files are moved from `Compile` to `PnpmCompile` to avoid `dotnet format` on TS files. | `src/**` |
 | CompileConfig[^1] | Inputs that could affect build configuration options. | `.*rc` and `*.json` files in the project root |
 | RestoreConfig[^1] | The inputs for the node restore configuration. | `$(PnpmRootPath)package.json`, `$(PnpmRootPath)pnpm-lock.yaml`, and `package.json` |
 | PnpmPackagedFiles | Additional inputs that will cause the packaged files to change | All CompileConfig items |

--- a/Pnpm/Sdk/Pnpm.targets
+++ b/Pnpm/Sdk/Pnpm.targets
@@ -43,10 +43,15 @@
         <CompileConfig Include=".*rc" Exclude="@(RestoreConfig)" />
         <CompileConfig Include="*.json" Exclude="@(RestoreConfig)" />
     </ItemGroup>
+    <ItemGroup Condition=" '@(Compile)' != '' ">
+        <PnpmCompile Include="@(Compile)" />
+        <Compile Remove="**/*" />
+    </ItemGroup>
     <ItemGroup Condition=" '@(PnpmCompile)' == '' ">
         <PnpmCompile Include="src/**" Watch="false" />
     </ItemGroup>
     <ItemGroup>
+        <Watch Include="@(PnpmCompile->HasMetadata('Watch')->WithMetadataValue('Watch','true'))" />
         <None Remove="node_modules/**/*" />
     </ItemGroup>
     <ItemGroup>
@@ -88,7 +93,7 @@
 	<PropertyGroup>
 		<PnpmRootPath>$(PnpmRootPath)</PnpmRootPath>
 	</PropertyGroup>
-	<Import Project="$(MSBuildThisFileDirectory)pnpm-install/pnpm-install.targets" />
+	<Import Project="$(MSBuildThisFileDirectory)pnpm-install/pnpm-install.targets" Condition="exists('$(MSBuildThisFileDirectory)pnpm-install/pnpm-install.targets')" />
 </Project>
             ]]></PnpmInstallProjectContents>
         </PropertyGroup>

--- a/Pnpm/Sdk/Pnpm.targets
+++ b/Pnpm/Sdk/Pnpm.targets
@@ -43,8 +43,8 @@
         <CompileConfig Include=".*rc" Exclude="@(RestoreConfig)" />
         <CompileConfig Include="*.json" Exclude="@(RestoreConfig)" />
     </ItemGroup>
-    <ItemGroup Condition=" '@(Compile)' == '' ">
-        <Compile Include="src/**" Watch="false" />
+    <ItemGroup Condition=" '@(PnpmCompile)' == '' ">
+        <PnpmCompile Include="src/**" Watch="false" />
     </ItemGroup>
     <ItemGroup>
         <None Remove="node_modules/**/*" />
@@ -123,7 +123,7 @@
     <Target Name="NodeBuild"
         Condition="'$(PnpmBuildScript)' != ''"
         BeforeTargets="Build"
-        Inputs="@(Compile);@(RestoreConfig);@(CompileConfig)"
+        Inputs="@(PnpmCompile);@(RestoreConfig);@(CompileConfig)"
         Outputs="@(CompileOutputs)">
         <Exec WorkingDirectory="$(ProjectDir)" Command="$(PnpmBuildScript)" />
         <Touch ForceTouch="true" Files="@(CompileOutputs)" />
@@ -137,7 +137,7 @@
     <Target Name="_PnpmLint"
         BeforeTargets="BeforeBuild"
         Condition="'$(PnpmLintScript)' != '' and '$(LintSkipPnpm)' != 'true' "
-        Inputs="@(Compile);@(RestoreConfig);@(CompileConfig)"
+        Inputs="@(PnpmCompile);@(RestoreConfig);@(CompileConfig)"
         Outputs="$(PnpmLintRecordPath)">
         <Exec WorkingDirectory="$(ProjectDir)" Command="$(PnpmLintScript)" />
         <Touch ForceTouch="true" Files="@(PnpmLintRecordPath)" />


### PR DESCRIPTION
Do not include PNPM src files in `dotnet format` by excluding from Compile items.