### PR TITLE
Filter optional file

### DIFF
--- a/Pnpm/Pnpm.csproj
+++ b/Pnpm/Pnpm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<VersionPrefix>0.2.1</VersionPrefix>
+		<VersionPrefix>0.2.2</VersionPrefix>
 
 		<IsPackable>true</IsPackable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Pnpm/Sdk/pnpm-install/pnpm-install.targets
+++ b/Pnpm/Sdk/pnpm-install/pnpm-install.targets
@@ -23,7 +23,7 @@
     <ItemGroup>
         <RestoreConfig Include="$(PnpmRootPath)package.json" />
         <RestoreConfig Include="$(PnpmRootPath)pnpm-lock.yaml" />
-        <RestoreConfig Include="package.json" />
+        <RestoreConfig Include="package.json" Condition=" Exists('package.json') " />
     </ItemGroup>
 
     <Target Name="PnpmInstall"


### PR DESCRIPTION
The global pnpm-install project that gets created will not have a package.json. Prior to this PR, that caused the PnpmInstall target to run every time.